### PR TITLE
fix: room 기본 아이템에 desk 추가 및 좌표 업데이트

### DIFF
--- a/src/room/room.constants.ts
+++ b/src/room/room.constants.ts
@@ -1,67 +1,75 @@
 export const DEFAULT_ROOM_ITEMS = [
 	{
+		name: 'windowDay',
+		x: 64.21,
+		y: 1,
+		zIndex: 1,
+		visible: true,
+		type: 'interior'
+	},
+	{
 		name: 'books',
-		x: 5,
+		x: 5.34,
 		y: 1,
 		zIndex: 1,
 		visible: true,
 		type: 'hobby'
 	},
 	{
-		name: 'movie',
-		x: 5,
-		y: 26,
-		zIndex: 1,
-		visible: true,
-		type: 'hobby'
-	},
-	{
 		name: 'music',
-		x: 15,
-		y: 12,
+		x: 12.65,
+		y: 11.89,
 		zIndex: 1,
 		visible: true,
 		type: 'hobby'
 	},
 	{
 		name: 'picture',
-		x: 50,
-		y: 16,
-		zIndex: 1,
-		visible: true,
-		type: 'interior'
-	},
-	{
-		name: 'plant',
-		x: 50,
-		y: 29,
+		x: 42.98,
+		y: 6.53,
 		zIndex: 1,
 		visible: true,
 		type: 'interior'
 	},
 	{
 		name: 'sofa',
-		x: 66.67,
-		y: 25.99,
-		zIndex: 1,
-		visible: true,
-		type: 'interior'
-	},
-	{
-		name: 'windowDay',
-		x: 65,
-		y: 3,
+		x: 68.07,
+		y: 28.39,
 		zIndex: 1,
 		visible: true,
 		type: 'interior'
 	},
 	{
 		name: 'windowNight',
-		x: 65,
-		y: 3,
+		x: 65.01,
+		y: 5.89,
 		zIndex: 1,
 		visible: true,
 		type: 'interior'
+	},
+	{
+		name: 'desk',
+		x: 8.47,
+		y: 33.78,
+		zIndex: 1,
+		visible: true,
+		type: 'interior'
+	},
+	{
+		name: 'plant',
+		x: 51.91,
+		y: 30.27,
+		zIndex: 1,
+		visible: true,
+		type: 'interior'
+	},
+	{
+		name: 'movie',
+		x: 12.97,
+		y: 25.39,
+		zIndex: 2,
+		visible: true,
+		type: 'hobby'
 	}
 ] as const;
 


### PR DESCRIPTION
## Summary
- Room 기본 아이템에 `desk` 추가 (`type: interior`)
- movie가 desk 위에 렌더링되도록 zIndex 설정 (movie: 2, 나머지: 1)
- 전체 아이템 좌표값 업데이트

## Test plan
- [ ] 새 유저 room 생성 시 desk 아이템 포함 확인
- [ ] 기존 유저 room 조회 시 정상 동작 확인 (desk 없이 반환)
- [ ] movie가 desk 위에 렌더링되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)